### PR TITLE
Make bounds functions available in user API.

### DIFF
--- a/pretty-poly.h
+++ b/pretty-poly.h
@@ -124,6 +124,9 @@ void pp_antialias(pp_antialias_t antialias);
 void pp_transform(pp_mat3_t *transform);
 void pp_render(pp_poly_t *polygon);
 
+pp_rect_t pp_contour_bounds(const pp_path_t *c);
+pp_rect_t pp_polygon_bounds(pp_poly_t *p);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I make this available to MicroPython for getting the bounds of a poly or poly group. Useful for applying clipping rects (as per vector clock smooth) for a erase/background pass before drawing.