### PR TITLE
Fix antialias bounds

### DIFF
--- a/examples/c/helpers.h
+++ b/examples/c/helpers.h
@@ -14,11 +14,11 @@ typedef union {
   uint32_t c;
 } colour;
 
-__attribute__((always_inline)) uint32_t alpha(uint32_t sa, uint32_t da) {
+__attribute__((always_inline)) inline uint32_t alpha(uint32_t sa, uint32_t da) {
   return ((sa + 1) * (da)) >> 8;
 }
 
-__attribute__((always_inline)) uint8_t blend_channel(uint8_t s, uint8_t d, uint8_t a) {
+__attribute__((always_inline)) inline uint8_t blend_channel(uint8_t s, uint8_t d, uint8_t a) {
   return d + ((a * (s - d) + 127) >> 8);
 }
 

--- a/pretty-poly.h
+++ b/pretty-poly.h
@@ -570,15 +570,15 @@ pp_rect_t render_nodes(pp_rect_t *tb) {
   // either 1 (at x4) or 3 (at x16) we change that to a "ceil" instead ensuring
   // the full tile bounds are returned
   if(_pp_antialias) {
-    rb.w += (_pp_antialias | 0b1);
-    rb.h += (_pp_antialias | 0b1);
+    int maxx = rb.x + rb.w + (_pp_antialias | 0b1);
+    int maxy = rb.y + rb.h + (_pp_antialias | 0b1);
+
+    rb.x >>= _pp_antialias;
+    rb.y >>= _pp_antialias;
+    rb.w = (maxx >> _pp_antialias) - rb.x;
+    rb.h = (maxy >> _pp_antialias) - rb.y;
   }
-
-  rb.x >>= _pp_antialias;
-  rb.y >>= _pp_antialias;
-  rb.w >>= _pp_antialias;
-  rb.h >>= _pp_antialias;
-
+  
   uint8_t *p_alpha_map = _pp_alpha_map_none;
   if(_pp_antialias == 1) p_alpha_map = _pp_alpha_map_x4;
   if(_pp_antialias == 2) p_alpha_map = _pp_alpha_map_x16;


### PR DESCRIPTION
When antialiasing, the last pixel could be clipped because simply rounding the width/height may be insufficient if the x/y coordinate gets rounded down.